### PR TITLE
Fix typo in oss-fuzz-coverage.yaml. (#297)

### DIFF
--- a/.github/workflows/test_fuzzer_benchmarks.py
+++ b/.github/workflows/test_fuzzer_benchmarks.py
@@ -59,11 +59,18 @@ def delete_docker_images():
     """Delete docker images."""
     # TODO(metzman): Don't delete base-runner/base-builder so it
     # doesn't need to be pulled for every target.
+
+    result = subprocess.run(['docker', 'ps', '-a', '-q'],
+                            stdout=subprocess.PIPE,
+                            check=True)
+    container_ids = result.stdout.splitlines()
+    subprocess.run(['docker', 'rm', '-f'] + container_ids, check=False)
+
     result = subprocess.run(['docker', 'images', '-a', '-q'],
                             stdout=subprocess.PIPE,
                             check=True)
-    image_names = result.stdout.splitlines()
-    subprocess.run(['docker', 'rmi', '-f'] + image_names, check=False)
+    image_ids = result.stdout.splitlines()
+    subprocess.run(['docker', 'rmi', '-f'] + image_ids, check=False)
 
 
 def make_builds(benchmarks, fuzzer):

--- a/docker/gcb/oss-fuzz-coverage.yaml
+++ b/docker/gcb/oss-fuzz-coverage.yaml
@@ -31,7 +31,7 @@ steps:
     'gcr.io/fuzzbench/builders/coverage/${_BENCHMARK}-intermediate',
 
     '--tag',
-    '${_REPO}/oss-fuzz/coverage/${_BENCHMARK}-intermediate',
+    '${_REPO}/builders/coverage/${_BENCHMARK}-intermediate',
 
     '--file=fuzzers/coverage/builder.Dockerfile',
 

--- a/fuzzers/aflsmart/builder.Dockerfile
+++ b/fuzzers/aflsmart/builder.Dockerfile
@@ -44,7 +44,7 @@ RUN git clone https://github.com/aflsmart/aflsmart /afl && \
 # Setup Peach.
 # Set CFLAGS="" so that we don't use the CFLAGS defined in OSS-Fuzz images.
 RUN cd /afl && \
-    wget https://sourceforge.net/projects/peachfuzz/files/Peach/3.0/peach-3.0.202-source.zip && \
+    wget https://storage.googleapis.com/fuzzbench-files/peach-3.0.202-source.zip && \
     unzip peach-3.0.202-source.zip && \
     patch -p1 < peach-3.0.202.patch && \
     cd peach-3.0.202-source && \

--- a/fuzzers/eclipser/runner.Dockerfile
+++ b/fuzzers/eclipser/runner.Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update -y && \
         bison \
         git \
         gdb
-RUN wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+RUN wget -q https://storage.googleapis.com/fuzzbench-files/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb && \
     apt-get update -y && \
     apt-get install -y dotnet-sdk-2.1 dotnet-runtime-2.1 && \


### PR DESCRIPTION
* Fix typo in oss-fuzz-coverage.yaml.

* Try fixing Eclipser ci failure.

* Fix CI issue due to dependent child images not getting deleted.

* Make CI reliable with GS links, rather than timeout on sourgeforge and
MS site.