### PR TITLE
Re-add and enable aflcc, disable klee, aflcc on unsupported benchmark…

### DIFF
--- a/.github/workflows/build_and_test_run_fuzzer_benchmarks.py
+++ b/.github/workflows/build_and_test_run_fuzzer_benchmarks.py
@@ -16,6 +16,7 @@
 import sys
 import subprocess
 
+from experiment.build import builder
 from src_analysis import change_utils
 from src_analysis import diff_utils
 
@@ -51,10 +52,9 @@ STANDARD_BENCHMARKS = {
 }
 
 
-def get_make_targets(benchmarks, fuzzer):
-    """Returns and test targets for |fuzzer| and each benchmark
-    in |benchmarks| to pass to make."""
-    return ['test-run-%s-%s' % (fuzzer, benchmark) for benchmark in benchmarks]
+def get_make_target(fuzzer, benchmark):
+    """Return test target for a fuzzer and benchmark."""
+    return 'test-run-%s-%s' % (fuzzer, benchmark)
 
 
 def delete_docker_images():
@@ -80,10 +80,11 @@ def delete_docker_images():
 
 def make_builds(benchmarks, fuzzer):
     """Use make to test the fuzzer on each benchmark in |benchmarks|."""
-    print('Building benchmarks: {} for fuzzer: {}'.format(
-        ', '.join(benchmarks), fuzzer))
-    make_targets = get_make_targets(benchmarks, fuzzer)
-    for make_target in make_targets:
+    fuzzer_benchmark_pairs = builder.get_fuzzer_benchmark_pairs([fuzzer],
+                                                                benchmarks)
+    print('Building fuzzer-benchmark pairs: {}'.format(fuzzer_benchmark_pairs))
+    for _, benchmark in fuzzer_benchmark_pairs:
+        make_target = get_make_target(fuzzer, benchmark)
         make_command = ['make', 'RUNNING_ON_CI=yes', '-j', make_target]
         print('Running command:', ' '.join(make_command))
         result = subprocess.run(make_command, check=False)

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         fuzzer:
           - afl
+          - aflcc
           - aflfast
           - aflplusplus
           - aflplusplus_optimal

--- a/benchmarks/bloaty_fuzz_target/benchmark.yaml
+++ b/benchmarks/bloaty_fuzz_target/benchmark.yaml
@@ -16,3 +16,5 @@ commit: 3cf5c3feca15ab88730d6526b2f06302597926b5
 commit_date: 2020-05-25 18:51:34+00:00
 fuzz_target: fuzz_target
 project: bloaty
+unsupported_fuzzers:
+  - klee

--- a/benchmarks/harfbuzz-1.3.2/benchmark.yaml
+++ b/benchmarks/harfbuzz-1.3.2/benchmark.yaml
@@ -14,3 +14,5 @@
 
 fuzz_target: fuzz-target
 project: harfbuzz
+unsupported_fuzzers:
+  - klee

--- a/benchmarks/jsoncpp_jsoncpp_fuzzer/benchmark.yaml
+++ b/benchmarks/jsoncpp_jsoncpp_fuzzer/benchmark.yaml
@@ -16,3 +16,5 @@ commit: 3beb37ea14aec1bdce1a6d542dc464d00f4a6cec
 commit_date: 2020-02-13 21:25:08+00:00
 fuzz_target: jsoncpp_fuzzer
 project: jsoncpp
+unsupported_fuzzers:
+  - klee

--- a/benchmarks/libjpeg-turbo-07-2017/benchmark.yaml
+++ b/benchmarks/libjpeg-turbo-07-2017/benchmark.yaml
@@ -14,3 +14,5 @@
 
 fuzz_target: fuzz-target
 project: libjpeg-turbo
+unsupported_fuzzers:
+  - aflcc

--- a/benchmarks/libpcap_fuzz_both/benchmark.yaml
+++ b/benchmarks/libpcap_fuzz_both/benchmark.yaml
@@ -16,3 +16,5 @@ commit: d615abec7e0237299250c409dca23effb8dd36cc
 commit_date: 2020-02-12 06:46:17+00:00
 fuzz_target: fuzz_both
 project: libpcap
+unsupported_fuzzers:
+  - klee

--- a/benchmarks/mbedtls_fuzz_dtlsclient/benchmark.yaml
+++ b/benchmarks/mbedtls_fuzz_dtlsclient/benchmark.yaml
@@ -16,3 +16,5 @@ commit: 4c08dd4e716c0c6d70d78117d3155c2b832f694e
 commit_date: 2020-02-11 08:17:02+00:00
 fuzz_target: fuzz_dtlsclient
 project: mbedtls
+unsupported_fuzzers:
+  - klee

--- a/benchmarks/openssl_x509/benchmark.yaml
+++ b/benchmarks/openssl_x509/benchmark.yaml
@@ -16,3 +16,5 @@ commit: b0593c086dd303af31dc1e30233149978dd613c4
 commit_date: 2020-02-10 09:22:32+00:00
 fuzz_target: x509
 project: openssl
+unsupported_fuzzers:
+  - klee

--- a/benchmarks/openthread-2019-12-23/benchmark.yaml
+++ b/benchmarks/openthread-2019-12-23/benchmark.yaml
@@ -14,3 +14,5 @@
 
 fuzz_target: fuzz-target
 project: openthread
+unsupported_fuzzers:
+  - klee

--- a/benchmarks/php_php-fuzz-parser/benchmark.yaml
+++ b/benchmarks/php_php-fuzz-parser/benchmark.yaml
@@ -16,3 +16,6 @@ commit: 3516a9c8f096a71f493b90fb6b2be3ee3b0f0293
 commit_date: 2020-06-30 16:43:40+00:00
 fuzz_target: php-fuzz-parser
 project: php
+unsupported_fuzzers:
+  - aflcc
+  - klee

--- a/benchmarks/systemd_fuzz-link-parser/benchmark.yaml
+++ b/benchmarks/systemd_fuzz-link-parser/benchmark.yaml
@@ -16,3 +16,6 @@ commit: 99fdffaa194cbfed659b0c1bfd0ace4bfcd2a245
 commit_date: 2020-02-10 16:19:52+00:00
 fuzz_target: fuzz-link-parser
 project: systemd
+unsupported_fuzzers:
+  - aflcc
+  - klee

--- a/benchmarks/vorbis-2017-12-11/benchmark.yaml
+++ b/benchmarks/vorbis-2017-12-11/benchmark.yaml
@@ -14,3 +14,5 @@
 
 fuzz_target: fuzz-target
 project: vorbis
+unsupported_fuzzers:
+  - klee

--- a/fuzzers/aflcc/aflcc_mock.c
+++ b/fuzzers/aflcc/aflcc_mock.c
@@ -1,0 +1,23 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdlib.h>
+#include <stdint.h>
+
+// these are defined in the LLVM passes, 
+// but need to be mocked for persistent mode.
+void __afl_manual_init(void) { printf("manual_init\n"); }
+int __afl_persistent_loop(unsigned int max_cnt) { printf("peristent loop\n"); return 0; }
+uint32_t __afl_get_area_size(void) { printf("get area size\n"); return 0; }
+uint32_t __afl_get_bbarea_size(void) { printf("bb area size\n"); return 0; }

--- a/fuzzers/aflcc/builder.Dockerfile
+++ b/fuzzers/aflcc/builder.Dockerfile
@@ -1,0 +1,71 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image=gcr.io/fuzzbench/base-builder
+FROM $parent_image
+
+# Need Clang/LLVM 3.8.
+RUN apt-get update -y && \
+    apt-get -y install llvm-3.8 \
+    clang-3.8 \
+    libstdc++-5-dev \
+    wget \
+    make \
+    gcc \
+    cmake \
+    texinfo \
+    bison \
+    software-properties-common
+
+# Install some libraries needed by some oss-fuzz benchmarks
+RUN apt-get install -y zlib1g-dev \
+    libarchive-dev \
+    libglib2.0-dev \
+    libpsl-dev \
+    libbsd-dev
+
+# Set env variables.
+ENV AFL_CONVERT_COMPARISON_TYPE=NONE
+ENV AFL_COVERAGE_TYPE=ORIGINAL
+ENV AFL_BUILD_TYPE=FUZZING
+ENV AFL_DICT_TYPE=NORMAL
+ENV LLVM_CONFIG=llvm-config-3.8
+
+
+# Download and compile aflcc.
+# Note: the commit number is for branch 'nodebug'
+RUN git clone https://github.com/Samsung/afl_cc.git /afl && \
+    cd /afl && \
+    git checkout c9486dfdf35b7d5f58ce4f9dae141031d2f9f3f1 && \
+    AFL_NO_X86=1 make && \
+    cd /afl/llvm_mode && \
+    CC=clang-3.8 CXX=clang++-3.8 CFLAGS= CXXFLAGS= make
+
+# Install gllvm
+RUN cd /afl && \
+    sh ./setup-aflc-gclang.sh
+
+#RUN apt-get install -y p7zip-full vim
+
+# Use afl_driver.cpp from LLVM as our fuzzing library.
+ENV CC=/afl/aflc-gclang
+ENV CXX=/afl/aflc-gclang++
+COPY aflcc_mock.c /aflcc_mock.c
+RUN wget https://raw.githubusercontent.com/llvm/llvm-project/master/compiler-rt/lib/fuzzer/afl/afl_driver.cpp -O /afl/afl_driver.cpp && \
+    sed -i -e '/decide_deferred_forkserver/,+8d' /afl/afl_driver.cpp && \
+    $CXX -I/usr/local/include/c++/v1/ -stdlib=libc++ -std=c++11 -O2 -c /afl/afl_driver.cpp -o /afl/afl_driver.o && \
+    ar r /libAFL.a /afl/afl_driver.o && \
+    clang-3.8 -O2 -c -fPIC /aflcc_mock.c -o /aflcc_mock.o && \
+    clang-3.8 -shared -o /libAflccMock.so /aflcc_mock.o
+    

--- a/fuzzers/aflcc/fuzzer.py
+++ b/fuzzers/aflcc/fuzzer.py
@@ -1,0 +1,378 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for AFLcc fuzzer."""
+
+import shutil
+import os
+import threading
+import subprocess
+
+from fuzzers import utils
+
+from fuzzers.afl import fuzzer as afl_fuzzer
+
+
+def is_benchmark(name):
+    """ Check if the benchmark contains the string 'name' """
+
+    # TODO: return name in os.environ['BENCHMARK]
+    # return benchmark is not None and name in benchmark
+
+    # OSS-fuzz benchmarks do not have a consistent folder content
+    # but typically have the name of the benchmark as part of the
+    # working directory.
+    pwd_dir = os.getcwd()
+
+    if name in pwd_dir:
+        return True
+
+    # Non-OSS-fuzz benchmarks.
+    src_dir = os.environ['SRC']
+    buildfile = os.path.join(src_dir, "benchmark/build.sh")
+    if not os.path.isfile(buildfile):
+        return False
+
+    with open(buildfile, 'r') as file:
+        content = file.read()
+        if name in content:
+            return True
+
+    return False
+
+
+def openthread_suppress_error_flags():
+    """Suppress errors for openthread"""
+    return [
+        '-Wno-error=embedded-directive',
+        '-Wno-error=gnu-zero-variadic-macro-arguments',
+        '-Wno-error=overlength-strings', '-Wno-error=c++11-long-long',
+        '-Wno-error=c++11-extensions', '-Wno-error=variadic-macros'
+    ]
+
+
+def libjpeg_turbo_asm_object_files():
+    """
+        Additional .o files compiled from .asm files
+        and absent from the LLVM .bc file we extracted
+        TODO(laurentsimon): check if we can link against
+        *.a instead of providing a list of .o files
+    """
+    return [
+        './BUILD/simd/jidctred-sse2-64.o', './BUILD/simd/jidctint-sse2-64.o',
+        './BUILD/simd/jidctfst-sse2-64.o', './BUILD/simd/jdmerge-sse2-64.o',
+        './BUILD/simd/jidctflt-sse2-64.o', './BUILD/simd/jdsample-sse2-64.o',
+        './BUILD/simd/jdcolor-sse2-64.o'
+    ]
+
+
+def fix_fuzzer_lib():
+    """Fix FUZZER_LIB for certain benchmarks"""
+
+    if '--warn-unresolved-symbols' not in os.environ['CFLAGS']:
+        os.environ['FUZZER_LIB'] += ' -L/ -lAflccMock -lpthread'
+
+    if is_benchmark('curl'):
+        shutil.copy('/libAflccMock.so', '/usr/lib/libAflccMock.so')
+
+    if is_benchmark('systemd'):
+        shutil.copy('/libAFL.a', '/usr/lib/libFuzzingEngine.a')
+        ld_flags = ['-lpthread']
+        utils.append_flags('LDFLAGS', ld_flags)
+
+
+def add_compilation_cflags():
+    """Add custom flags for certain benchmarks"""
+    if is_benchmark('openthread'):
+        openthread_flags = openthread_suppress_error_flags()
+        utils.append_flags('CFLAGS', openthread_flags)
+        utils.append_flags('CXXFLAGS', openthread_flags)
+
+    elif is_benchmark('php'):
+        php_flags = ['-D__builtin_cpu_supports\\(x\\)=0']
+        utils.append_flags('CFLAGS', php_flags)
+        utils.append_flags('CXXFLAGS', php_flags)
+
+    # For some benchmarks, we also tell the compiler
+    # to ignore unresolved symbols. This is useful when we cannot change
+    # the build process to add a shared library for linking
+    # (which contains mocked functions: libAflccMock.so).
+    # Note that some functions are only defined post-compilation
+    # during the LLVM passes.
+    elif is_benchmark('bloaty') or is_benchmark('openssl') or is_benchmark(
+            'systemd'):
+        unresolved_flags = ['-Wl,--warn-unresolved-symbols']
+        utils.append_flags('CFLAGS', unresolved_flags)
+        utils.append_flags('CXXFLAGS', unresolved_flags)
+
+    elif is_benchmark('curl'):
+        dl_flags = ['-ldl', '-lpsl']
+        utils.append_flags('CFLAGS', dl_flags)
+        utils.append_flags('CXXFLAGS', dl_flags)
+
+
+def add_post_compilation_lflags(ldflags_arr):
+    """Add additional linking flags for certain benchmarks"""
+    if is_benchmark('libjpeg'):
+        ldflags_arr += libjpeg_turbo_asm_object_files()
+    elif is_benchmark('php'):
+        ldflags_arr += ['-lresolv']
+    elif is_benchmark('curl'):
+        ldflags_arr += [
+            '-ldl', '-lpsl', '/src/openssl/libcrypto.a', '/src/openssl/libssl.a'
+        ]
+    elif is_benchmark('openssl'):
+        ldflags_arr += ['/src/openssl/libcrypto.a', '/src/openssl/libssl.a']
+    elif is_benchmark('systemd'):
+        shutil.copy(
+            os.path.join(os.environ['OUT'],
+                         'src/shared/libsystemd-shared-245.so'),
+            '/usr/lib/libsystemd-shared-245.so')
+        ldflags_arr += ['-lsystemd-shared-245']
+
+
+def prepare_fuzz_environment(input_corpus):
+    """Prepare run for some benchmarks"""
+    afl_fuzzer.prepare_fuzz_environment(input_corpus)
+
+    # OUT env variable does not exists, it seems.
+    if os.path.isfile('/out/src/shared/libsystemd-shared-245.so'):
+        shutil.copy('/out/src/shared/libsystemd-shared-245.so',
+                    '/usr/lib/libsystemd-shared-245.so')
+
+
+def prepare_build_environment():
+    """Set environment variables used to build benchmark."""
+    utils.set_no_sanitizer_compilation_flags()
+
+    # Update compiler flags for clang-3.8.
+    cflags = ['-fPIC']
+    cppflags = cflags + [
+        '-I/usr/local/include/c++/v1/', '-stdlib=libc++', '-std=c++11'
+    ]
+    utils.append_flags('CFLAGS', cflags)
+    utils.append_flags('CXXFLAGS', cppflags)
+
+    # Add flags for various benchmarks.
+    add_compilation_cflags()
+
+    # Setup aflcc compiler.
+    os.environ['LLVM_CONFIG'] = 'llvm-config-3.8'
+    os.environ['CC'] = '/afl/aflc-gclang'
+    os.environ['CXX'] = '/afl/aflc-gclang++'
+    os.environ['FUZZER_LIB'] = '/libAFL.a'
+
+    # Fix FUZZER_LIB for various benchmarks.
+    fix_fuzzer_lib()
+
+
+def get_fuzz_targets():
+    """Get the fuzz target name"""
+    # For non oss-projects, FUZZ_TARGET contain the target binary.
+    fuzz_target = os.getenv('FUZZ_TARGET', None)
+    if fuzz_target is not None:
+        return [fuzz_target]
+
+    print('FUZZ_TARGET is not defined')
+
+    # For these benchmarks, only return one file.
+    targets = {
+        'curl': 'curl_fuzzer_http',
+        'openssl': 'x509',
+        'systemd': 'fuzz-link-parser',
+        'php': 'php-fuzz-parser'
+    }
+
+    for target, fuzzname in targets.items():
+        if is_benchmark(target):
+            return [os.path.join(os.environ['OUT'], fuzzname)]
+
+    # For the reamining oss-projects, use some heuristics.
+    # We look for binaries in the OUT directory and take it as our targets.
+    # Note that we may return multiple binaries: this is necessary because
+    # sometimes multiple binaries are generated and we don't know which will
+    # be used for fuzzing (e.g., zlib benchmark).
+    # dictionary above.
+    out_dir = os.environ['OUT']
+    files = os.listdir(out_dir)
+    fuzz_targets = []
+    for filename in files:
+        candidate_bin = os.path.join(out_dir, filename)
+        if 'fuzz' in filename and os.access(candidate_bin, os.X_OK):
+            fuzz_targets += [candidate_bin]
+
+    if len(fuzz_targets) == 0:
+        raise ValueError("Cannot find binary")
+    return fuzz_targets
+
+
+def post_build(fuzz_target):
+    """Perform the post-processing for a target"""
+    print('Fuzz-target: {target}'.format(target=fuzz_target))
+
+    getbc_cmd = "/afl/aflc-get-bc {target}".format(target=fuzz_target)
+    if os.system(getbc_cmd) != 0:
+        raise ValueError("get-bc failed")
+
+    # Set the flags. ldflags is here temporarily until the benchmarks
+    # are cleaned up and standalone.
+    cppflags_arr = [
+        '-I/usr/local/include/c++/v1/', '-stdlib=libc++', '-std=c++11'
+    ]
+    # Note: -ld for dlopen(), -lbsd for strlcpy().
+    ldflags_arr = [
+        '-lpthread', '-lm', ' -lz', '-larchive', '-lglib-2.0', '-ldl', '-lbsd'
+    ]
+
+    # Add post compilation linking flags for certain benchmarks.
+    add_post_compilation_lflags(ldflags_arr)
+
+    # Stringify the flags arrays.
+    cppflags = ' '.join(cppflags_arr)
+    ldflags = ' '.join(ldflags_arr)
+
+    # Create the different build types.
+    os.environ['AFL_BUILD_TYPE'] = 'FUZZING'
+
+    # The original afl binary.
+    print('[post_build] Generating original afl build')
+    os.environ['AFL_COVERAGE_TYPE'] = 'ORIGINAL'
+    os.environ['AFL_CONVERT_COMPARISON_TYPE'] = 'NONE'
+    os.environ['AFL_DICT_TYPE'] = 'NORMAL'
+    bin1_cmd = '{compiler} {flags} -O3 {target}.bc -o ' \
+    '{target}-original {ldflags}'.format(
+        compiler='/afl/aflc-clang-fast++',
+        flags=cppflags,
+        target=fuzz_target,
+        ldflags=ldflags)
+    if os.system(bin1_cmd) != 0:
+        raise ValueError('command "{command}" failed'.format(command=bin1_cmd))
+
+    # The normalized build with non-optimized dictionary.
+    print('[post_build] Generating normalized-none-nopt')
+    os.environ['AFL_COVERAGE_TYPE'] = 'ORIGINAL'
+    os.environ['AFL_CONVERT_COMPARISON_TYPE'] = 'NONE'
+    os.environ['AFL_DICT_TYPE'] = 'NORMAL'
+    bin2_cmd = '{compiler} {flags} {target}.bc -o ' \
+    '{target}-normalized-none-nopt {ldflags}'.format(
+        compiler='/afl/aflc-clang-fast++',
+        flags=cppflags,
+        target=fuzz_target,
+        ldflags=ldflags)
+    if os.system(bin2_cmd) != 0:
+        raise ValueError('command "{command}" failed'.format(command=bin2_cmd))
+
+    # The no-collision split-condition optimized dictionary.
+    print('[post_build] Generating no-collision-all-opt build')
+    os.environ['AFL_COVERAGE_TYPE'] = 'NO_COLLISION'
+    os.environ['AFL_CONVERT_COMPARISON_TYPE'] = 'ALL'
+    os.environ['AFL_DICT_TYPE'] = 'OPTIMIZED'
+    bin3_cmd = '{compiler} {flags} {target}.bc -o ' \
+    '{target}-no-collision-all-opt {ldflags}'.format(
+        compiler='/afl/aflc-clang-fast++',
+        flags=cppflags,
+        target=fuzz_target,
+        ldflags=ldflags)
+    if os.system(bin3_cmd) != 0:
+        raise ValueError('command "{command}" failed'.format(command=bin3_cmd))
+
+    print('[post_build] Copying afl-fuzz to $OUT directory')
+    # Copy out the afl-fuzz binary as a build artifact.
+    shutil.copy('/afl/afl-fuzz', os.environ['OUT'])
+
+
+def build():
+    """Build benchmark."""
+    prepare_build_environment()
+
+    utils.build_benchmark()
+
+    print('[post_build] Extracting .bc file')
+    fuzz_targets = get_fuzz_targets()
+    for fuzz_target in fuzz_targets:
+        post_build(fuzz_target)
+
+
+def run_fuzzer(input_corpus,
+               output_corpus,
+               target_binary,
+               additional_flags=None,
+               hide_output=False):
+    """Run afl-fuzz."""
+    # Spawn the afl fuzzing process.
+    # FIXME: Currently AFL will exit if it encounters a crashing input in seed
+    # corpus (usually timeouts). Add a way to skip/delete such inputs and
+    # re-run AFL.
+    print('[run_fuzzer] Running target with afl-fuzz')
+    command = [
+        './afl-fuzz',
+        '-i',
+        input_corpus,
+        '-o',
+        output_corpus,
+        # Use no memory limit as ASAN doesn't play nicely with one.
+        '-m',
+        'none'
+    ]
+    if additional_flags:
+        command.extend(additional_flags)
+    dictionary_path = utils.get_dictionary_path(target_binary)
+    if dictionary_path:
+        command.extend(['-x', dictionary_path])
+    command += [
+        '--',
+        target_binary,
+        # Pass INT_MAX to afl the maximize the number of persistent loops it
+        # performs.
+        '2147483647'
+    ]
+    print('[run_fuzzer] Running command: ' + ' '.join(command))
+    output_stream = subprocess.DEVNULL if hide_output else None
+    subprocess.check_call(command, stdout=output_stream, stderr=output_stream)
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+    prepare_fuzz_environment(input_corpus)
+
+    # Note: dictionary automatically added by run_fuzzer().
+
+    # Use a dictionary for original afl as well.
+    print('[fuzz] Running AFL for original binary')
+    src_file = '{target}-normalized-none-nopt.dict'.format(target=target_binary)
+    dst_file = '{target}-original.dict'.format(target=target_binary)
+    shutil.copy(src_file, dst_file)
+    # Instead of generating a new dict, just hack this one
+    # to be non-optimized to prevent AFL from aborting.
+    os.system('sed -i \'s/OPTIMIZED/NORMAL/g\' {dict}'.format(dict=dst_file))
+    afl_fuzz_thread1 = threading.Thread(
+        target=run_fuzzer,
+        args=(input_corpus, output_corpus,
+              '{target}-original'.format(target=target_binary),
+              ['-S', 'slave-original']))
+    afl_fuzz_thread1.start()
+
+    print('[run_fuzzer] Running AFL for normalized and optimized dictionary')
+    afl_fuzz_thread2 = threading.Thread(
+        target=run_fuzzer,
+        args=(input_corpus, output_corpus,
+              '{target}-normalized-none-nopt'.format(target=target_binary),
+              ['-S', 'slave-normalized-nopt']))
+    afl_fuzz_thread2.start()
+
+    print('[run_fuzzer] Running AFL for FBSP and optimized dictionary')
+    run_fuzzer(input_corpus,
+               output_corpus,
+               '{target}-no-collision-all-opt'.format(target=target_binary),
+               ['-S', 'slave-no-collision-all-opt'],
+               hide_output=False)

--- a/fuzzers/aflcc/runner.Dockerfile
+++ b/fuzzers/aflcc/runner.Dockerfile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-commit: 376d5bb323c03c0fc4af266c03abac8f067fbd0e
-commit_date: 2020-07-26 21:48:36+00:00
-fuzz_target: curl_fuzzer_http
-project: curl
-unsupported_fuzzers:
-  - klee
+FROM gcr.io/fuzzbench/base-runner
+
+RUN apt-get install -y zlib1g-dev \
+    libarchive-dev \
+    libglib2.0-dev \
+    libpsl-dev \
+    libbsd-dev
+

--- a/fuzzers/klee/builder.Dockerfile
+++ b/fuzzers/klee/builder.Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -y && \
     clang-6.0 llvm-6.0-dev llvm-6.0-tools \
     wget
 
-# Install KLEE dependencies
+# Install KLEE dependencies.
 RUN apt-get install -y \
     cmake-data build-essential curl libcap-dev \
     git cmake libncurses5-dev python-minimal \
@@ -31,14 +31,14 @@ RUN apt-get install -y \
 
 ENV INSTALL_DIR=/out
 
-# Install minisat
+# Install minisat.
 RUN git clone https://github.com/stp/minisat.git /minisat && \
     cd /minisat && mkdir build && cd build && \
     CXXFLAGS= cmake -DSTATIC_BINARIES=ON \
     -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DCMAKE_BUILD_TYPE=Release ../ && \
     make -j`nproc` && make install
 
-# Install STP solver
+# Install STP solver.
 RUN git clone https://github.com/stp/stp.git /stp && \
     cd /stp && git checkout tags/2.1.2 && \
     mkdir build && cd build && \


### PR DESCRIPTION
…s. (#737)

* Re-add and enable aflcc, disable klee, aflcc on unsupported benchmarks.

Fixes #586.

This reverts commit ff12d02b80e16cd206c18037a6f9e92c191f348b.

* Fix missing newlines.

* Fix CI to also do filtering.