### PR TITLE
compare afl++ and eclipser to 2x afl++ (#1006)

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -56,6 +56,7 @@ jobs:
           - aflplusplus_cmplog
           - aflplusplus_dict2file
           - aflplusplus_eclipser
+          - aflplusplus_double
 
         benchmark_type:
           - oss-fuzz

--- a/fuzzers/aflplusplus/fuzzer.py
+++ b/fuzzers/aflplusplus/fuzzer.py
@@ -172,7 +172,7 @@ def build(*args):  # pylint: disable=too-many-branches,too-many-statements
         shutil.copy('/aflpp_qemu_driver_hook.so', build_directory)
 
 
-def fuzz(input_corpus, output_corpus, target_binary, flags=tuple()):
+def fuzz(input_corpus, output_corpus, target_binary, flags=tuple(), skip=False):
     """Run fuzzer."""
     # Calculate CmpLog binary path from the instrumented target binary.
     target_binary_directory = os.path.dirname(target_binary)
@@ -188,14 +188,15 @@ def fuzz(input_corpus, output_corpus, target_binary, flags=tuple()):
     # os.environ['AFL_PRELOAD'] = '/afl/libdislocator.so'
 
     flags = list(flags)
-    if not flags or not flags[0] == '-Q' and '-p' not in flags:
-        flags += ['-p', 'fast']
-    if os.path.exists(cmplog_target_binary):
-        flags += ['-c', cmplog_target_binary]
-    if os.path.exists('./afl++.dict'):
-        flags += ['-x', './afl++.dict']
-    if 'ADDITIONAL_ARGS' in os.environ:
-        flags += os.environ['ADDITIONAL_ARGS'].split(' ')
+    if not skip:
+        if not flags or not flags[0] == '-Q' and '-p' not in flags:
+            flags += ['-p', 'fast']
+        if os.path.exists(cmplog_target_binary):
+            flags += ['-c', cmplog_target_binary]
+        if os.path.exists('./afl++.dict'):
+            flags += ['-x', './afl++.dict']
+        if 'ADDITIONAL_ARGS' in os.environ:
+            flags += os.environ['ADDITIONAL_ARGS'].split(' ')
 
     afl_fuzzer.run_afl_fuzz(input_corpus,
                             output_corpus,

--- a/fuzzers/aflplusplus_double/builder.Dockerfile
+++ b/fuzzers/aflplusplus_double/builder.Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG parent_image
+FROM $parent_image
+
+# Install libstdc++ to use llvm_mode.
+RUN apt-get update && \
+    apt-get install -y wget libstdc++-5-dev libtool-bin automake flex bison \
+                       libglib2.0-dev libpixman-1-dev python3-setuptools unzip \
+                       apt-utils apt-transport-https ca-certificates
+
+# Download and compile afl++.
+RUN git clone https://github.com/AFLplusplus/AFLplusplus.git /afl && \
+    cd /afl && \
+    git checkout a4fd4ea0f46529feb09577a13cc7c053fb22146f
+
+# Build without Python support as we don't need it.
+# Set AFL_NO_X86 to skip flaky tests.
+RUN cd /afl && unset CFLAGS && unset CXXFLAGS && \
+    export CC=clang && export AFL_NO_X86=1 && \
+    PYTHON_INCLUDE=/ make && make install && \
+    make -C utils/aflpp_driver && \
+    cp utils/aflpp_driver/libAFLDriver.a /

--- a/fuzzers/aflplusplus_double/description.md
+++ b/fuzzers/aflplusplus_double/description.md
@@ -1,0 +1,14 @@
+# aflplusplus + eclipser 2.0
+
+AFL++ fuzzer instance that uses Eclipser 2.0
+  - PCGUARD instrumentation 
+  - dict2file feature
+  - "fast" power schedule
+  - persistent mode + shared memory test cases
+
+Repository: [https://github.com/AFLplusplus/AFLplusplus/](https://github.com/AFLplusplus/AFLplusplus/)
+Repository: [https://github.com/SoftSec-KAIST/Eclipser](https://github.com/SoftSec-KAIST/Eclipser)
+
+[builder.Dockerfile](builder.Dockerfile)
+[fuzzer.py](fuzzer.py)
+[runner.Dockerfile](runner.Dockerfile)

--- a/fuzzers/aflplusplus_double/fuzzer.py
+++ b/fuzzers/aflplusplus_double/fuzzer.py
@@ -1,0 +1,69 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration code for Eclipser fuzzer. Note that starting from v2.0, Eclipser
+relies on AFL to perform random-based fuzzing."""
+
+import os
+import shutil
+import threading
+
+from fuzzers.aflplusplus import fuzzer as aflplusplus_fuzzer
+
+
+def get_uninstrumented_outdir(target_directory):
+    """Return path to uninstrumented target directory."""
+    return os.path.join(target_directory, 'uninstrumented')
+
+
+def build():
+    """Build benchmark."""
+    build_directory = os.getenv('OUT')
+    aflplusplus_fuzzer.build("tracepc", "cmplog", "dict2file")
+    shutil.copy('/afl/afl-fuzz', build_directory)
+
+
+def afl_worker1(input_corpus, output_corpus, target_binary):
+    """Run AFL worker instance."""
+    print('[afl_worker] Run AFL worker')
+    aflplusplus_fuzzer.fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            flags=(['-S', 'afl-worker1', '-x', 'afl++.dict']))
+
+
+def afl_worker2(input_corpus, output_corpus, target_binary):
+    """Run AFL worker instance."""
+    print('[afl_worker] Run AFL worker')
+    aflplusplus_fuzzer.fuzz(input_corpus,
+                            output_corpus,
+                            target_binary,
+                            flags=(['-S', 'afl-worker2']),
+                            skip=True)
+
+
+def fuzz(input_corpus, output_corpus, target_binary):
+    """Run fuzzer."""
+
+    if not os.path.isdir(input_corpus):
+        raise Exception("invalid input directory")
+    afl_args = (input_corpus, output_corpus, target_binary)
+    print('[fuzz] Running AFL worker 1')
+    afl_worker_thread = threading.Thread(target=afl_worker1, args=afl_args)
+    afl_worker_thread.start()
+    print('[fuzz] Running AFL workser 2')
+    eclipser_thread = threading.Thread(target=afl_worker2, args=afl_args)
+    eclipser_thread.start()
+    print('[fuzz] Now waiting for threads to finish...')
+    afl_worker_thread.join()
+    eclipser_thread.join()

--- a/fuzzers/aflplusplus_double/runner.Dockerfile
+++ b/fuzzers/aflplusplus_double/runner.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/fuzzbench/base-image
+
+# This makes interactive docker runs painless:
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
+ENV AFL_MAP_SIZE=2222222
+ENV PATH="$PATH:/out"
+ENV AFL_SKIP_CPUFREQ=1
+ENV AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+ENV AFL_TESTCACHE_SIZE=2

--- a/service/experiment-requests.yaml
+++ b/service/experiment-requests.yaml
@@ -19,6 +19,13 @@
 # You can run "make presubmit" to do basic validation on this file.
 # Please add new experiment requests towards the top of this file.
 
+- experiment: 2020-12-26
+  description: "compare aflplusplus_eclipser vs aflplusplus_double"
+  fuzzers:
+    - aflplusplus
+    - aflplusplus_eclipser
+    - aflplusplus_double
+
 - experiment: 2020-12-25
   description: "best of current state"
   fuzzers:


### PR DESCRIPTION
* new run

* fixes

* change moved directory

* more schedule enhancement tests

* fix fore new weight variants

* add 300c release

* update config

* request experiment

* update to pre-300c commit id

* support bug benchmarks

* remove unnecessary imports

* more _optimal support

* more _optimal support

* new experiment

* fix compile on fuzzbench

* fix compile on fuzzbench

* fix bug in skim

* make presubmit happy

* fix yaml

* new targets have a larger map

* dummy

* aflplusplus_qemu fix

* presubmit fix

* remove temporary variants, update commit id

* fix compiles, update optimal to llvm12

* fix qemu

* remove temporary variants, update commit id

* request new experiment

* fix py

* fix lto

* request new experiment

* add afl++ and eclipser

* add afl++ and eclipser

* add afl++ and eclipser

* make presubmit happy

* fix presubmit

* fix a build for afl++ eclipser

* add double variant

* add double variant

* add double variant

* fix fuzzer.py

* fix presubmit

* fix presubmit