### PR TITLE
Update honggfuzz to the newest version (b56729e6f29672be2edb288580784…

### DIFF
--- a/benchmarks/openexr_openexr_exrenvmap_fuzzer/build.sh
+++ b/benchmarks/openexr_openexr_exrenvmap_fuzzer/build.sh
@@ -17,6 +17,10 @@
 
 cd $WORK/
 
+# /work/OpenEXR/libOpenexrUtils.a contains duplicated symbols,
+# so instruct the linker not to complain about it.
+export CXXFLAGS="$CXXFLAGS -Wl,-z,muldefs"
+
 CMAKE_SETTINGS=(
   "-D BUILD_SHARED_LIBS=OFF"         # Build static libraries only
   "-D PYILMBASE_ENABLE=OFF"          # Don't build Python support

--- a/fuzzers/honggfuzz/builder.Dockerfile
+++ b/fuzzers/honggfuzz/builder.Dockerfile
@@ -23,14 +23,14 @@ RUN apt-get update -y && \
     libblocksruntime-dev \
     liblzma-dev
 
-# Download honggfuz version 2.3.1 + d9482931f22e532ae1948e4eb933e5d6c2c52ead
+# Download honggfuz version 2.3.1 + b56729e6f29672be2edb2885807844df68d8db32
 # Set CFLAGS use honggfuzz's defaults except for -mnative which can build CPU
 # dependent code that may not work on the machines we actually fuzz on.
 # Create an empty object file which will become the FUZZER_LIB lib (since
 # honggfuzz doesn't need this when hfuzz-clang(++) is used).
 RUN git clone https://github.com/google/honggfuzz.git /honggfuzz && \
     cd /honggfuzz && \
-    git checkout d9482931f22e532ae1948e4eb933e5d6c2c52ead && \
+    git checkout b56729e6f29672be2edb2885807844df68d8db32 && \
     CFLAGS="-O3 -funroll-loops" make && \
     touch empty_lib.c && \
     cc -c -o empty_lib.o empty_lib.c


### PR DESCRIPTION
…4df68d8db32) (#1066)

* Update honggfuzz to the newest version (b56729e6f29672be2edb2885807844df68d8db32)

* Use -Wl,-z,muldefs when linking OpenEXR fuzzing targets

One of the archives used to build the final fuzzer binary
contains duplicated symbols (e.g. typeinfo for ImageChannel)
so instruct the linker to ignore it.