### PR TITLE
symqemu: fix up so its working

### DIFF
--- a/fuzzers/symqemu_aflplusplus/builder.Dockerfile
+++ b/fuzzers/symqemu_aflplusplus/builder.Dockerfile
@@ -73,3 +73,24 @@ RUN cd / && \
     clang -O2 -c /StandaloneFuzzTargetMain.c && \
     ar rc /libStandaloneFuzzTarget.a StandaloneFuzzTargetMain.o && \
     rm /StandaloneFuzzTargetMain.c
+
+
+RUN git clone https://github.com/eurecom-s3/symqemu --depth 1 /symqemu/src
+RUN mkdir /symqemu/build && \
+    cd /symqemu/build && \
+    ../src/configure                                              \
+      --audio-drv-list=                                           \
+      --disable-bluez                                             \
+      --disable-sdl                                               \
+      --disable-gtk                                               \
+      --disable-vte                                               \
+      --disable-opengl                                            \
+      --disable-virglrenderer                                     \
+      --target-list=x86_64-linux-user                             \
+      --enable-capstone=git                                       \
+      --disable-werror                                            \
+      --symcc-source=/symcc/                                  \
+      --symcc-build=/symcc/build  && \
+    make && \
+    cd /symqemu && \
+    rm -rf src

--- a/fuzzers/symqemu_aflplusplus/runner.Dockerfile
+++ b/fuzzers/symqemu_aflplusplus/runner.Dockerfile
@@ -16,10 +16,10 @@ FROM gcr.io/fuzzbench/base-image
 
 RUN apt-get install -y wget
 RUN sed -i -- 's/# deb-src/deb-src/g' /etc/apt/sources.list
-RUN echo deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main >> /etc/apt/sources.list && \
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu xenial main >> /etc/apt/sources.list && \
-    apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 1E9377A2BA9EF27F
+#RUN echo deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main >> /etc/apt/sources.list && \
+#    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+#RUN echo deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu xenial main >> /etc/apt/sources.list && \
+#    apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 1E9377A2BA9EF27F
 RUN apt-get update && \
     apt-get install -y wget libstdc++-5-dev libtool-bin automake flex bison \
                        libglib2.0-dev libpixman-1-dev python3-setuptools unzip \
@@ -52,54 +52,6 @@ RUN apt-get install -y \
         gdb \
         strace
 RUN apt-get build-dep -y qemu
-
-# Install Z3 from binary
-RUN wget -qO /tmp/z3x64.zip https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-ubuntu-16.04.zip && \
-     unzip -jd /usr/include /tmp/z3x64.zip "*/include/*.h" && \
-     unzip -jd /usr/lib /tmp/z3x64.zip "*/bin/libz3.so" && \
-     rm -f /tmp/*.zip && \
-     ldconfig
-
-ENV CFLAGS=""
-ENV CXXFLAGS=""
-
-RUN pip3 install lit
-RUN cd / && wget https://github.com/ninja-build/ninja/releases/download/v1.10.1/ninja-linux.zip && \
-    unzip ninja-linux.zip && chmod 755 ninja && mv ninja /usr/local/bin && rm ninja-linux.zip
-RUN apt-get install -y \
-        clang-10 \
-        llvm-10-dev \
-        llvm-10-tools \
-        libllvm10
-RUN apt-get install -y gcc-9 g++-9 libstdc++-9-dev
-RUN apt-get install -y libgnutls28-dev libshishi-dev libshishi0 shishi-common
-
-ENV CC=clang-10
-ENV CXX=clang++-10
-ENV PATH=/usr/bin:$PATH
-
-RUN cd / && git clone --depth=1 https://github.com/vanhauser-thc/adacc /symcc && \
-    cd /symcc && git checkout 72b5687a6e3d1e5e477b10e77dd0047611b6b5b9
-
-RUN cd /usr/bin && ln -s llvm-config-10 llvm-config && \
-    ln -s clang-10 clang && ln -s clang++-10 clang++
-
-RUN cd /symcc && \
-    cd ./runtime/qsym_backend && \
-    git clone https://github.com/adalogics/qsym && \
-    cd qsym && \
-    git checkout adalogics && \
-    cd /symcc && \
-    mkdir build && \
-    cd build && \
-    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DQSYM_BACKEND=ON \
-          -DZ3_TRUST_SYSTEM_VERSION=ON ../ && \
-    ninja -j 3 && \
-    cd ../examples && \
-    export SYMCC_PC=1 && \
-    ../build/symcc -c ./libfuzz-harness-proxy.c -o /libfuzzer-harness.o && \
-    cd ../ && echo "[+] Installing cargo now 4" && \
-    cargo install --path util/symcc_fuzzing_helper
 
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/out"
 


### PR DESCRIPTION
This fixes things up such that symqemu_aflplusplus is working. I have tested it with
```
make build-symqemu_aflplusplus-libhtp_fuzz_htp
make run-symqemu_aflplusplus-libhtp_fuzz_htp
```

There is a small amount of cleanup to be done, however, the symqemu is working now in that it runs and produces testcases. However, there are some issues with the afl-showmap logic, which means no testacases are copied over to the afl queue. 

I added some logic to bypass the afl-showmap completely in this commit https://github.com/AdaLogics/adacc/commit/2ebf6a97f618ba2769be18cfa6e4c2f4d7122576 (see the "-m") option, but it looks like you removed it in this commit https://github.com/vanhauser-thc/adacc/commit/72b5687a6e3d1e5e477b10e77dd0047611b6b5b9 

I think it would be good to get this solved before launching an experiment on fuzzbench. If you do a PR with your adacc fork (https://github.com/vanhauser-thc/adacc/) then I am happy to merge things in and ensure things are running. Once that has been done then I can go through a bit more of the fuzzbench benchmarks and verify things are working as they should. At that point I can also cleanup things here.